### PR TITLE
armcc compiler error - ezpression must be a pointer to a complete obj…

### DIFF
--- a/WIZnet/W7500x_toe.cpp
+++ b/WIZnet/W7500x_toe.cpp
@@ -294,7 +294,7 @@ int WIZnet_Chip::send(int socket, const void * str, int len)
     uint32_t sn_tx_base = W7500x_TXMEM_BASE + (uint32_t)(socket<<18); 
 
     for(int i=0; i<len; i++)
-        *(volatile uint8_t *)(sn_tx_base + ((ptr+i)&0xFFFF)) = *(uint8_t *)(str+i);
+        *(volatile uint8_t *)(sn_tx_base + ((ptr+i)&0xFFFF)) = *(uint8_t *)((uint8_t *)str+i);
 
     sreg<uint16_t>(socket, Sn_TX_WR, ptr + len);
     scmd(socket, SEND);
@@ -333,7 +333,7 @@ int WIZnet_Chip::recv(int socket, void* buf, int len)
     uint32_t sn_rx_base = W7500x_RXMEM_BASE + (uint32_t)(socket<<18); 
 
     for(int i=0; i<len; i++)
-       *(uint8_t *)(buf+i) = *(volatile uint8_t *)(sn_rx_base + ((ptr+i)&0xFFFF));
+       *(uint8_t *)((uint8_t *)buf+i) = *(volatile uint8_t *)(sn_rx_base + ((ptr+i)&0xFFFF));
 
     sreg<uint16_t>(socket, Sn_RX_RD, ptr + len);
     scmd(socket, RECV);

--- a/WIZnetInterface.cpp
+++ b/WIZnetInterface.cpp
@@ -25,6 +25,7 @@ static int udp_local_port = 0;
 
 #define SKT(h) ((wiznet_socket*)h)
 #define WIZNET_WAIT_TIMEOUT   400
+#define WIZNET_WAIT_TIMEOUT1   1000
 #define WIZNET_ACCEPT_TIMEOUT 300000 //5 mins timeout, retrun NSAPI_ERROR_WOULD_BLOCK if there is no connection during 5 mins
 
 #define WIZNET_INTF_DBG 0
@@ -395,7 +396,7 @@ nsapi_size_or_error_t WIZnetInterface::socket_connect(nsapi_socket_t handle, con
     SKT(handle)->connected = false;
 
     //try to connect
-    if (!_wiznet.connect(SKT(handle)->fd, address.get_ip_address(), address.get_port(), WIZNET_WAIT_TIMEOUT)) {
+    if (!_wiznet.connect(SKT(handle)->fd, address.get_ip_address(), address.get_port(), WIZNET_WAIT_TIMEOUT1)) {
         _mutex.unlock();
         return -1;
     }
@@ -502,7 +503,7 @@ nsapi_size_or_error_t WIZnetInterface::socket_send(nsapi_socket_t handle, const 
         if (_size > (size-writtenLen)) {
             _size = (size-writtenLen);
         }
-        ret = _wiznet.send(SKT(handle)->fd, (char*)(data+writtenLen), (int)_size);
+        ret = _wiznet.send(SKT(handle)->fd, (char*)((uint32_t *)data+writtenLen), (int)_size);
         if (ret < 0) {
             DBG("returning error -1\n");
             _mutex.unlock();
@@ -518,7 +519,7 @@ nsapi_size_or_error_t WIZnetInterface::socket_recv(nsapi_socket_t handle, void *
 {
     int recved_size = 0;
     //int idx;
-    nsapi_size_t _size;
+    int _size;
     nsapi_size_or_error_t err;
 
     DBG("fd: %d\n", SKT(handle)->fd);
@@ -555,7 +556,7 @@ nsapi_size_or_error_t WIZnetInterface::socket_recv(nsapi_socket_t handle, void *
         }
 
 
-        err = _wiznet.recv(SKT(handle)->fd, (char*)(data + recved_size), (int)_size);
+        err = _wiznet.recv(SKT(handle)->fd, (char*)((uint32_t *)data + recved_size), (int)_size);
 //	    printf("[TEST 400] : %d\r\n",recved_size);
 //	    for(idx=0; idx<16; idx++)
 //	    {


### PR DESCRIPTION
…ect type  : void pointer bariable 수식 연산 오류로 임시 형변환 추가 4지점 수정

socket_connect에서 Timeout 따로 설정 후 1000으로 설정
socket_recb에서 _size의 자료형 int로 변경 -  변경전  unsigend여서 return 값 받아올 때 에러로 -1을 받아오는데 unsigend로 받으면 잘못 받아와 메세지를 받은것 처럼 인식됨